### PR TITLE
Fix CI failing ( `docs` dir missing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "textlint ajax architecture async browser exercise language nodejs *.md",
     "start": "gitbook serve",
-    "build": "rm -rf docs/**/* && gitbook build && cp -a _book/* docs",
+    "build": "rm -rf docs/**/* && gitbook build && mkdir -p docs && cp -a _book/* docs",
     "pdf": "gitbook pdf . hatena-textbook-javascript.pdf"
   },
   "repository": {


### PR DESCRIPTION
`npm run build` fails because "docs" dir not exist.

## actual behavior

```shell
$ docker run -it -v $(pwd):/src/book node:6 bash
root@d3762558d850:/# cd src/book
root@d3762558d850:/src/book# npm install
npm WARN Hatena-Textbook-JavaScript@0.0.0 license should be a valid SPDX license expression
root@d3762558d850:/src/book# ls
README.md   ajax.md          async.md    deploy_key.enc   jquery.md     nodejs             package.json        tmp-43mG5Zo6ygPQKi
SUMMARY.md  architecture     browser     exercise         language      nodejs.md          prepare.md          yarn.lock
_book       architecture.md  browser.md  exercise.md      language.md   omake.md           tmp-29maf7fEPmrueQ
ajax        async            deploy.sh   jquery-logo.png  node_modules  package-lock.json  tmp-306yEKes1iNLrY
root@d3762558d850:/src/book# npm run build

> Hatena-Textbook-JavaScript@0.0.0 build /src/book
> rm -rf docs/**/* && gitbook build && cp -a _book/* docs

Installing GitBook 3.2.3
gitbook@3.2.3 tmp-40UDJdqqnec1OV/node_modules/gitbook
# ...snip..
info: 7 plugins are installed
info: 6 explicitly listed
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "sharing"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-default"... OK
info: found 35 pages
info: found 17 asset files
info: >> generation finished with success in 6.1s !
cp: target 'docs' is not a directory

npm ERR! Linux 5.2.9-arch1-1-ARCH
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "build"
npm ERR! node v6.17.1
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! Hatena-Textbook-JavaScript@0.0.0 build: `rm -rf docs/**/* && gitbook build && cp -a _book/* docs`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the Hatena-Textbook-JavaScript@0.0.0 build script 'rm -rf docs/**/* && gitbook build && cp -a _book/* docs'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the Hatena-Textbook-JavaScript package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     rm -rf docs/**/* && gitbook build && cp -a _book/* docs
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs Hatena-Textbook-JavaScript
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls Hatena-Textbook-JavaScript
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /src/book/npm-debug.log
root@d3762558d850:/src/book#
```